### PR TITLE
Fix: Update GridItem coordinate property for v0.4.2 beta

### DIFF
--- a/AutoRestock/AutoRestock.csproj
+++ b/AutoRestock/AutoRestock.csproj
@@ -31,6 +31,8 @@
 		<Configurations>IL2CPP;Mono</Configurations>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <!-- ADD THIS LINE -->
 	</PropertyGroup>
 
 	<!-- Hide libs directory of other Configuration -->


### PR DESCRIPTION
Changed OriginCoordinate -> _originCoordinate in SerializeSlot() and DeserializeSlot() methods using reflection to maintain compatibility with game's beta update.